### PR TITLE
Remove italics on message link

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -276,7 +276,7 @@ async function onMessage(ws, resume, ev)
 							name: quotedUser.nick || quotedUser.user.username,
 							icon_url: quotedUser.user.avatar && "https://cdn.discordapp.com/avatars/" + quotedUser.user.id + "/" + quotedUser.user.avatar + ".png",
 						},
-						description: quotedMsg.content + `\n[*Link*](https://discord.com/channels/${messageData.guild_id}/${messageData.channel_id}/${messageData.message_id})`,
+						description: quotedMsg.content + `\n[Link](https://discord.com/channels/${messageData.guild_id}/${messageData.channel_id}/${messageData.message_id})`,
 					};
 					const img = re.exec(quotedMsg.content);
 					if(img !== null)


### PR DESCRIPTION
Quote formatting breaks when un-terminated formatting characters are part of the quoted message/

Examples:
![image](https://user-images.githubusercontent.com/13784116/97096458-5fae8b00-16b8-11eb-9bdd-e2e0c6c4a2e8.png)

